### PR TITLE
Handle early termination of main loop in pipeline.run

### DIFF
--- a/src/crisposon/parsers.py
+++ b/src/crisposon/parsers.py
@@ -8,8 +8,8 @@ def parse_blast_xml(blast_xml, blast_id):
     Queries (ORFs) for which no alignments were returned
     are excluded from the output.
 
-    Returns a dictionary of dictionaries if hits 
-    were found; otherwise, returns an empty dictionary.
+    Returns a dictionary of dictionaries if hits print(len(self.hits))
+    were found; otherwise, returns None.
 
     Args:
         blast_xml(str): Path to blast output.

--- a/src/crisposon/steps.py
+++ b/src/crisposon/steps.py
@@ -73,7 +73,11 @@ class SeedBlastpsi(Blastpsi):
         self.orfs = orfs
         blast_out = self.run_blast()
         self.hits = parse_blast_xml(blast_out, self.name)
-        self.neighborhood_ranges = get_neighborhood_ranges(self.hits, self.span)
+
+        if len(self.hits) != 0:
+            self.neighborhood_ranges = get_neighborhood_ranges(self.hits, self.span)
+        else:
+            self.neighborhood_ranges = None
 
 class SeedBlastp(Blastp):
 
@@ -88,7 +92,11 @@ class SeedBlastp(Blastp):
         self.orfs = orfs
         blast_out = self.run_blast()
         self.hits = parse_blast_xml(blast_out, self.name)
-        self.neighborhood_ranges = get_neighborhood_ranges(self.hits, self.span)
+        
+        if len(self.hits) != 0:
+            self.neighborhood_ranges = get_neighborhood_ranges(self.hits, self.span)
+        else:
+            self.neighborhood_ranges = None
 
 class FilterBlastpsi(Blastpsi):
 


### PR DESCRIPTION
Main loop in pipeline now safely terminates when all ORFs have been discarded, or when the initial seed phase does not produce any hits. When an early termination occurs, pipeline.run() returns an empty dictionary. 