### PR TITLE
Automatically install wheel if it's not present already during setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    setup_requires=['wheel'],
 )


### PR DESCRIPTION
If the `wheel` package isn't present the install **might** fail with the message `error: invalid command 'bdist_wheel'`. For some reason this only occurred on one of three computers I've installed this library on. Regardless, if `wheel` is missing it will be automatically installed now.