### PR TITLE
Fix distance finding when multiple copies of the same feature exist

### DIFF
--- a/src/operon_analyzer/rules.py
+++ b/src/operon_analyzer/rules.py
@@ -104,7 +104,9 @@ class FilterSet(object):
 
 def _must_be_within_n_bp_of_anything(operon: Operon, ignored_reason_message: str, distance_bp: int):
     for feature in operon.all_features:
-        distances = _calculate_all_distances(operon, feature.name)
+        distances = _calculate_all_distances(operon, feature)
+        if not distances:
+            continue
         if min(distances) > distance_bp:
             feature.ignore(ignored_reason_message)
 
@@ -220,21 +222,23 @@ def _require(operon: Operon, feature_name: str) -> bool:
 
 
 def _max_distance(operon: Operon, feature1_name: str, feature2_name: str, distance_bp: int) -> bool:
-    """ Returns whether two given Features are within distance_bp base pairs from each other. """
-    f1 = operon.get_unique(feature1_name)
-    f2 = operon.get_unique(feature2_name)
-    if f1 is None or f2 is None:
+    """ Returns whether two given Features are within distance_bp base pairs from each other.
+    This must hold for all copies of the features with the same name. """
+    distances = []
+    for f1 in operon.get(feature1_name):
+        for f2 in operon.get(feature2_name):
+            if f1 is f2:
+                continue
+            distance = _feature_distance(f1, f2)
+            distances.append(distance)
+    if not distances:
         return False
-    distance = _feature_distance(f1, f2)
-    return 0 <= distance <= distance_bp
+    return all([0 <= distance <= distance_bp for distance in distances])
 
 
-def _calculate_all_distances(operon: Operon, feature_name: str) -> Optional[int]:
+def _calculate_all_distances(operon: Operon, feature: Feature) -> Optional[int]:
     """ Calculates the distance of a unique feature to all other features. """
     distances = []
-    feature = operon.get_unique(feature_name)
-    if feature is None:
-        return None
     for other_feature in operon:
         if feature is other_feature:
             continue
@@ -245,20 +249,30 @@ def _calculate_all_distances(operon: Operon, feature_name: str) -> Optional[int]
 
 def _at_least_n_bp_from_anything(operon: Operon, feature_name: str, distance_bp: int) -> bool:
     """ Whether a given feature is more than distance_bp base pairs from another Feature. """
-    distances = _calculate_all_distances(operon, feature_name)
-    if distances is None:
-        return False
-    if not distances:
-        return True
-    return min(distances) >= distance_bp
+    at_least_one_good = False
+    for feature in operon.get(feature_name):
+        distances = _calculate_all_distances(operon, feature)
+        if distances is None:
+            return False
+        if not distances:
+            return True
+        if min(distances) < distance_bp:
+            return False
+        at_least_one_good = True
+    return at_least_one_good
 
 
 def _at_most_n_bp_from_anything(operon: Operon, feature_name: str, distance_bp: int) -> bool:
     """ Whether a given feature is less than distance_bp base pairs from any other feature. """
-    distances = _calculate_all_distances(operon, feature_name)
-    if distances is None:
-        return False
-    return min(distances) <= distance_bp
+    at_least_one_good = False
+    for feature in operon.get(feature_name):
+        distances = _calculate_all_distances(operon, feature)
+        if distances is None:
+            return False
+        if min(distances) > distance_bp:
+            return False
+        at_least_one_good = True
+    return at_least_one_good
 
 
 def _same_orientation(operon: Operon, args=None) -> bool:

--- a/tests/test_operon_analyzer/test_analyze.py
+++ b/tests/test_operon_analyzer/test_analyze.py
@@ -63,6 +63,24 @@ def _find_plotted_features(ax):
     return features
 
 
+@pytest.mark.parametrize('feature_name,expected', [
+    ('cas2', True),
+    ('cas1', False)
+    ])
+def test_multicopy_feature(feature_name, expected):
+    genes = [
+            Feature('cas1', (12, 400), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (410, 600), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (620, 1200), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            Feature('cas2', (1220, 1300), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas1', (2000, 2200), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            ]
+    operon = Operon('QCDRTU', 0, 3400, genes)
+    rs = RuleSet().at_most_n_bp_from_anything(feature_name, 25)
+    result = rs.evaluate(operon)
+    assert result.is_passing is expected
+
+
 def test_create_operon_figure_with_ignored():
     operon = _get_standard_operon()
     fs = FilterSet().must_be_within_n_bp_of_feature('cas2', 10)


### PR DESCRIPTION
We were just giving up in the event where two or more features had the same name and this led to a situation where a distance was not being correctly calculated.
This commit changes our strategy and requires that any rule that applies to a particular feature must pass for all copies.

Resolves #51.