### PR TITLE
Make operon analyzer use CSV writer to generate output

### DIFF
--- a/src/operon_analyzer/overview.py
+++ b/src/operon_analyzer/overview.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Tuple, Dict, DefaultDict, Iterator, IO
+from typing import Tuple, Dict, DefaultDict, Iterator, IO, List
 from operon_analyzer.analyze import load_analyzed_operons
 
 
@@ -20,7 +20,7 @@ def _extract_results(lines: Iterator[Tuple[str, int, int, str]]) -> Iterator[str
         yield result
 
 
-def _count_results(results: Iterator[str]) -> Tuple[Dict[str, int],
+def _count_results(results: Iterator[List[str]]) -> Tuple[Dict[str, int],
                                                     Dict[str, int],
                                                     Dict[int, int]]:
     """
@@ -38,21 +38,20 @@ def _count_results(results: Iterator[str]) -> Tuple[Dict[str, int],
     for result in results:
         # result will either be the singular word "pass", or the word "fail" followed
         # by space-separated rules that the operon broke
-        data = result.split()
-        if data[0] == 'pass':
+        if result[0] == 'pass':
             # there were no failed rules
             rule_failure_counts[0] += 1
         else:
             # there was at least one failed rule
-            assert data[0] == 'fail'
-            for rule in data[1:]:
+            assert result[0] == 'fail'
+            for rule in result[1:]:
                 failed_rule_occurrences[rule] += 1
                 all_rules.add(rule)
-            if len(data) == 2:
+            if len(result) == 2:
                 # there was exactly one failed rule
                 unique_rule_violated[rule] += 1
             # keep track of how many failed rules there were
-            rule_failure_counts[len(data[1:])] += 1
+            rule_failure_counts[len(result[1:])] += 1
 
     # Ensure rules with zero counts are represented in the data
     for rule in all_rules:

--- a/src/operon_analyzer/rules.py
+++ b/src/operon_analyzer/rules.py
@@ -53,14 +53,6 @@ class Result(object):
         assert (self._passing or self._failing), "Result has no Rules!"
         return bool(self._passing) and not bool(self._failing)
 
-    def __repr__(self) -> str:
-        outcome = "pass" if self.is_passing else "fail %s" % " ".join(str(rule) for rule in self._failing)
-        text = "{contig},{start}..{end},{outcome}"
-        return text.format(
-                contig=self.operon.contig,
-                start=self.operon.start,
-                end=self.operon.end,
-                outcome=outcome)
 
 
 class Filter(SerializableFunction):

--- a/tests/integration/integration_data/operon_analyzer/analysis.csv
+++ b/tests/integration/integration_data/operon_analyzer/analysis.csv
@@ -1,7 +1,7 @@
-# require:transposase,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1
-CRISPR-transposases,7470..79575,fail require:transposase max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1
-CRISPR-transposases,15630..37621,pass
-CRISPR-transposases,102222..122929,fail exclude:cas3 max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1
-CRISPR-transposases,251014..293071,fail exclude:cas3 max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1
-CRISPR-transposases,320249..367608,fail exclude:cas3 max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1
-CRISPR-transposases,687691..709163,pass
+#,require:transposase,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1
+CRISPR-transposases,7470,79575,fail,require:transposase,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1
+CRISPR-transposases,15630,37621,pass
+CRISPR-transposases,102222,122929,fail,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1
+CRISPR-transposases,251014,293071,fail,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1
+CRISPR-transposases,320249,367608,fail,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1
+CRISPR-transposases,687691,709163,pass

--- a/tests/integration/test_operon_analyze.py
+++ b/tests/integration/test_operon_analyze.py
@@ -108,7 +108,7 @@ def visualize(condition: str):
             operons = build_operon_dictionary(f)
         with open(analysis_csv) as f:
             for contig, start, end, result in load_analyzed_operons(f):
-                if not result.startswith(condition):
+                if not result[0].startswith(condition):
                     continue
                 op = operons.get((contig, start, end))
                 if op is None:

--- a/tests/test_operon_analyzer/test_analyze.py
+++ b/tests/test_operon_analyzer/test_analyze.py
@@ -1,6 +1,5 @@
 from operon_analyzer.genes import Feature, Operon
 from operon_analyzer.rules import RuleSet, _feature_distance, _max_distance, _contains_features, FilterSet, _calculate_overlap, _pick_overlapping_features_by_bit_score
-from operon_analyzer.analyze import _serialize_results
 from operon_analyzer.visualize import calculate_adjusted_operon_bounds, create_operon_figure
 from operon_analyzer.overview import _count_results
 from operon_analyzer.parse import _parse_feature
@@ -235,15 +234,15 @@ def test_calculate_adjusted_operon_bounds():
 
 
 def test_count_results():
-    csv_text = [
-            'fail exclude:cas3 max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1',
-            'fail require:transposase max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1',
+    csv_text = [line.split(',') for line in [
+            'fail,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1',
+            'fail,require:transposase,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1',
             'pass',
-            'fail exclude:cas3',
-            'fail require:transposase',
-            'fail exclude:cas3 max-distance-to-anything:transposase-500 min-distance-to-anything:transposase-1',
-            'fail max-distance-to-anything:transposase-500',
-            'fail exclude:cas3'
+            'fail,exclude:cas3',
+            'fail,require:transposase',
+            'fail,exclude:cas3,max-distance-to-anything:transposase-500,min-distance-to-anything:transposase-1',
+            'fail,max-distance-to-anything:transposase-500',
+            'fail,exclude:cas3']
             ]
     unique_rule_violated, failed_rule_occurrences, rule_failure_counts = _count_results(csv_text)
     expected_urv = {'exclude:cas3': 2,
@@ -528,17 +527,6 @@ def test_at_most_n_bp_from_anything(distance: int, expected: bool):
     rs = RuleSet().at_most_n_bp_from_anything('transposase', distance)
     result = rs.evaluate(operon)
     assert result.is_passing is expected
-
-
-def test_serialize_results_fail():
-    operon = _get_standard_operon()
-    rs = RuleSet() \
-        .exclude('cas3') \
-        .require('cas12a')
-    result = rs.evaluate(operon)
-    actual = "\n".join(_serialize_results(rs, [result]))
-    expected = "# exclude:cas3,require:cas12a\nQCDRTU,0..3400,fail require:cas12a"
-    assert actual == expected
 
 
 @pytest.mark.parametrize('gene1_start,gene1_end,gene2_start,gene2_end', [


### PR DESCRIPTION
Since we were simply splitting on spaces to determine which rules failed, a feature with spaces in its name would not be properly handled. Using the CSV writer allows for arbitrary names. Resolves #53.