### PR TITLE
Switch to yaml.full_load() to avoid a warning message.

### DIFF
--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -9,7 +9,7 @@ def setup_pipeline():
 
     # load contents of yaml conf file
     stream = open(conf_file, 'r')
-    conf = yaml.load(stream)
+    conf = yaml.full_load(stream)
 
     p = Pipeline()
     for step in conf["steps"]:

--- a/tests/integration/test_pipeline_run_options.py
+++ b/tests/integration/test_pipeline_run_options.py
@@ -7,7 +7,7 @@ def create_pipeline(conf_file):
 
     # load contents of yaml conf file
     stream = open(conf_file, 'r')
-    conf = yaml.load(stream)
+    conf = yaml.full_load(stream)
 
     p = Pipeline()
     for step in conf["steps"]:


### PR DESCRIPTION
A bunch of unhelpful warnings are displayed when running slow tests due to a deprecation warning. This uses a different method to load yaml files. This only affects tests and won't impact the actual pipeline.