### PR TITLE
Resolves #71: Use ORF amino acid sequences instead of alignments in output

### DIFF
--- a/src/crisposon/pipeline.py
+++ b/src/crisposon/pipeline.py
@@ -368,7 +368,7 @@ class Pipeline:
         self._steps.append(CrisprStep(Pilercr("CRISPR")))
     
 
-    def _update_orf_sequences(self):
+    def _update_output_sequences(self):
         for neighborhood, path in self._neighborhood_orfs.items():
             sequences = {}
             for record in SeqIO.parse(path, "fasta"):
@@ -530,7 +530,7 @@ class Pipeline:
                         break
 
                 self._all_hits[contig_id][step.search_tool.step_id] = step.hits
-                self._update_orf_sequences()
+                self._update_output_sequences()
                 self._results[contig_id] = self._working_results
         
         self._format_results(outfrmt, outfile)


### PR DESCRIPTION
The pipeline was saving the alignment character string for each putative hit, since it's returned by BLAST anyway. However, it would probably be better to have the full query sequence, since the alignment sequence that BLAST outputs is often shorter than the query sequence and contains gap characters.

Rather than adding another column to the pipeline output csv, this just replaces the alignment sequence with the ORF amino acid sequence in the output. 