### PR TITLE
Dynamically adjust figure width so that tick labels don't overlap.

### DIFF
--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -65,7 +65,7 @@ def create_operon_figure(operon: Operon, plot_ignored: bool, feature_colors: Opt
     record = GraphicRecord(sequence_length=operon_length,
                            features=graphic_features)
 
-    ax, _ = record.plot(figure_width=5)
+    ax, _ = record.plot(figure_width=max(int(operon_length/900), 1))
     record.plot(ax)
     return ax
 


### PR DESCRIPTION
The problem was that the figure width was hard coded to 5. Basing it on the size of the operon ensures good spacing, at least with some arbitrary operons I tested. Here I'm setting the width as the operon length in bp divided by 900, which empirically gives good spacing and makes features large and easy to read. This may need to be adjusted in the future. The wider the figure width, the better the label spacing, but the worse the legibility of the features.

Resolves #99.