### PR TITLE
Add method to cluster operons by motif and plot their operon figures …

### DIFF
--- a/src/operon_analyzer/analyze.py
+++ b/src/operon_analyzer/analyze.py
@@ -1,8 +1,9 @@
 import csv
-from typing import Iterator, IO, Tuple, Optional
+from collections import defaultdict
+from typing import Iterator, IO, Tuple, Optional, List, Dict, Set
 from operon_analyzer.genes import Operon
 from operon_analyzer.rules import RuleSet, Result, FilterSet
-from operon_analyzer.parse import assemble_operons, read_pipeline_output
+from operon_analyzer.parse import assemble_operons, read_pipeline_output, load_operons
 import sys
 
 
@@ -47,3 +48,31 @@ def _evaluate_operons(operons: Iterator[Operon], ruleset: RuleSet, filterset: Op
         if filterset is not None:
             filterset.evaluate(operon)
         yield ruleset.evaluate(operon)
+
+
+def cluster_operons_by_feature_order(operons: Iterator[Operon]):
+    """ Organizes all operons into a dictionary based on the order/identity of the features.
+    Cases where the overall order is inverted are considered to be the same. The keys of the dictionary
+    are the dash-delimited feature names, with one of the two orientations (if both exist) arbitrarily chosen.
+    If there are ignored features, they will not appear in the key. """
+    bins = defaultdict(list)
+    for operon in operons:
+        feature_names = _get_sorted_feature_names(operon)
+        reverse_feature_names = tuple(reversed(feature_names))
+        if reverse_feature_names not in bins:
+            bins[feature_names].append(operon)
+        else:
+            bins[reverse_feature_names].append(operon)
+    return bins
+
+
+def _get_diffed_cluster_keys(clustered_operons: Dict[str, Operon], diff_against: Dict[str, Operon]) -> Set[str]:
+    """ Given two sets of clustered operons, we want to know what the unique keys are that exist in `clustered_operons` so we can later only plot those. """
+    return set(clustered_operons.keys()) - set(diff_against.keys())
+
+
+def _get_sorted_feature_names(operon: Operon) -> List[str]:
+    """ Produces a list of feature names, ordered by the lowest genomic coordinate
+    (that is, regardless of the orientation of the feature, whichever end has the lowest
+    numbered nucleotide position is what is used here). """
+    return tuple((feature.name for feature in sorted(operon, key=lambda feat: feat.start)))

--- a/src/operon_analyzer/parse.py
+++ b/src/operon_analyzer/parse.py
@@ -3,10 +3,17 @@ from gene_finder.output_writers import FIELDNAMES
 from collections import defaultdict
 from typing import Tuple, Iterator, IO
 from operon_analyzer.genes import Feature, Operon
+import sys
 
+
+csv.field_size_limit(sys.maxsize)
 
 PipelineRecord = Tuple[str, str, str, str, str, str, str, str, str, str]
 Coordinates = Tuple[int, int]
+
+
+def load_operons(handle: IO[str]) -> Iterator[Operon]:
+    yield from assemble_operons(read_pipeline_output(handle))
 
 
 def assemble_operons(lines: Iterator[PipelineRecord]) -> Iterator[Operon]:

--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -1,11 +1,15 @@
 import os
 import sys
-from typing import Tuple, Dict, IO, List, Optional
+from typing import Tuple, Dict, IO, List, Optional, Iterable, Set
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from dna_features_viewer import GraphicFeature, GraphicRecord
 from operon_analyzer.genes import Operon
 from operon_analyzer.parse import assemble_operons, read_pipeline_output
+from operon_analyzer import analyze
+
+
+ContigDescriptor = Tuple[str, str, int, int]  # contig accession ID, contig filename, start coordinate, end coordinate
 
 
 def build_image_filename(operon: Operon, directory: str = None) -> str:
@@ -93,3 +97,83 @@ def plot_operons(operons: List[Operon], output_directory: str, plot_ignored: boo
         if ax is None:
             continue
         save_operon_figure(ax, out_filename)
+
+
+def _load_passing_contigs(handle: IO):
+    good_contigs = set()
+    for contig, contig_filename, start, end, result in analyze.load_analyzed_operons(handle):
+        if result[0] != 'pass':
+            continue
+        good_contigs.add((contig, contig_filename, start, end))
+    return good_contigs
+
+
+def make_clustered_operon_plots(analysis_csv: str,
+                                operons: Iterable[Operon],
+                                image_directory: str,
+                                min_count: int = 10,
+                                diff_against_csv: Optional[str] = None,
+                                plot_ignored: bool = False,
+                                feature_colors: Optional[dict] = None
+                                ):
+    """ Clusters operons by the order of their features and plots them in separate directories,
+    adding the number of systems to the directory name. Only systems that passed the Ruleset will
+    be eligible to be plotted.
+
+    If a FilterSet was used during analysis, that same FilterSet should be evaluated on each operon before passing it
+    into this function.
+
+    analysis_csv:       path to the CSV file created by operon analyzer
+    operons:            the operons of interest
+    image_directory:    the directory where all subdirectories will be created. Will be created if it does not exist
+    min_count:          groups must have at least this many systems in order to be plotted
+    diff_against_csv:   path to a CSV file created by operon analyzer. Any clusters in this file
+                        will be skipped when clustering operons from analysis_csv. The point of
+                        this is to see only new systems when making slight alterations to rules
+    plot_ignored:       plot ignored features
+    feature_colors:     a dictionary of feature names and their colors
+    """
+    with open(analysis_csv) as f:
+        passing_contigs = _load_passing_contigs(f)
+
+    diff_contigs = set()
+    if diff_against_csv is not None:
+        with open(diff_against_csv) as f:
+            diff_contigs = _load_passing_contigs(f)
+
+    if not os.path.exists(image_directory):
+        os.mkdir(image_directory)
+
+    plottable_operons = []
+    diff_operons = []
+
+    for operon in operons:
+        key = operon.contig, operon.contig_filename, operon.start, operon.end
+        if key in passing_contigs:
+            plottable_operons.append(operon)
+        if key in diff_contigs:
+            diff_operons.append(operon)
+
+    all_clustered_operons = analyze.cluster_operons_by_feature_order(plottable_operons)
+    diff_clustered_operon_motifs = set(analyze.cluster_operons_by_feature_order(diff_operons).keys())
+    plottable_operons = {k: ops for k, ops in all_clustered_operons.items()
+                         if k not in diff_clustered_operon_motifs and len(ops) >= min_count}
+    _plot_clustered_operons(plottable_operons, image_directory, plot_ignored, feature_colors)
+
+
+def _plot_clustered_operons(clustered_operons: Dict[str, List[Operon]], image_dir: str, plot_ignored: bool, feature_colors: Optional[dict]):
+    """ Plots contigs, placing them in directories named by the count and motif of the operons.
+    For example, if there are 527 operons with Cas9, glmS, a CRISPR array, and Cas1 (in that order or exactly reversed),
+    the directory name will be 527-cas9-glms-array-cas1. """
+    for motif_items, operons in clustered_operons.items():
+        motif_name = '-'.join(motif_items)
+        motif_directory = _make_motif_directory_name(motif_name, len(operons), image_dir)
+        os.mkdir(motif_directory)
+        plot_operons(operons, motif_directory, plot_ignored=plot_ignored, feature_colors=feature_colors)
+
+
+def _make_motif_directory_name(motif_name: str, num_operons: int, image_dir: str) -> str:
+    """ Makes a string to use as a directory name for some set of operons with the same motif """
+    motif_name = motif_name.replace("CRISPR array", "array").replace(" ", "_")
+    motif_name = f"{num_operons}-{motif_name}"
+    return os.path.join(image_dir, motif_name)

--- a/tests/test_operon_analyzer/test_analyze.py
+++ b/tests/test_operon_analyzer/test_analyze.py
@@ -1,0 +1,75 @@
+from operon_analyzer.genes import Feature, Operon
+from operon_analyzer import analyze
+
+
+def test_sort_feature_names():
+    genes = [
+            Feature('cas1', (1210, 4000), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (410, 600), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (620, 1200), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    actual = analyze._get_sorted_feature_names(operon)
+    expected = ('cas2', 'cas4', 'cas1')
+    assert actual == expected
+
+
+def test_sort_feature_names2():
+    genes = [
+            Feature('cas1', (4000, 1200), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (410, 600), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (620, 2200), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    actual = analyze._get_sorted_feature_names(operon)
+    expected = ('cas2', 'cas4', 'cas1')
+    assert actual == expected
+
+
+def test_sort_feature_names3():
+    genes = [
+            Feature('cas2', (4000, 1200), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas1', (410, 600), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (620, 2200), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    actual = analyze._get_sorted_feature_names(operon)
+    expected = ('cas1', 'cas4', 'cas2')
+    assert actual == expected
+
+
+def test_cluster_operons_by_feature_order():
+    genes = [
+            Feature('cas1', (1, 100), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (200, 300), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (400, 500), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon1 = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    genes = [
+            Feature('cas4', (1, 100), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (200, 300), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas1', (400, 500), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon2 = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    genes = [
+            Feature('cas1', (1, 100), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (200, 300), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (400, 500), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon3 = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    genes = [
+            Feature('cas1', (1, 100), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas4', (400, 500), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon4 = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    genes = [
+            Feature('transposase', (1, 100), 'lcl|12|400|1|-1', 1, 'ACACEHFEF', 4e-19, 'a good gene', 'MCGYVER'),
+            Feature('cas2', (200, 300), 'lcl|410|600|1|-1', 1, 'FGEYFWCE', 2e-5, 'a good gene', 'MGFRERAR'),
+            Feature('cas4', (400, 500), 'lcl|620|1200|1|-1', 1, 'NFBEWFUWEF', 6e-13, 'a good gene', 'MLAWPVTLE'),
+            ]
+    operon5 = Operon('QCDRTU', '/tmp/dna.fasta', 0, 13400, genes)
+    operons = [operon1, operon2, operon3, operon4, operon5]
+    classified = {name: len(ops) for name, ops in analyze.cluster_operons_by_feature_order(operons).items()}
+    expected = {('cas1', 'cas2', 'cas4'): 3, ('cas1', 'cas4'): 1, ('transposase', 'cas2', 'cas4'): 1}
+    assert classified == expected
+


### PR DESCRIPTION
…in common directories.

The only issue with this is that operons need to have their filterset re-evaluated before
being passed to the relevant function, or else features that were ignored in the analysis
will reappear here and will dilute meaningful results. I don't see any obvious fix for this,
but regardless it's out of scope for this issue and this is still useful.

Resolves #107.