### PR TITLE
Fix broken visualization tests

### DIFF
--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -69,7 +69,8 @@ def create_operon_figure(operon: Operon, plot_ignored: bool, feature_colors: Opt
     record = GraphicRecord(sequence_length=operon_length,
                            features=graphic_features)
 
-    ax, _ = record.plot(figure_width=max(int(operon_length/900), 1))
+    figure_width = max(int(operon_length/900), 5)
+    ax, _ = record.plot(figure_width=figure_width)
     record.plot(ax)
     return ax
 


### PR DESCRIPTION
The figure_width parameter for DNA features viewer was 1. The tests were failing with this value. Increasing the minimum to 5 avoids the error and also appears to work well for operons with 2 or 3 genes (i.e. no overlapping genome coordinates on the X axis).