### PR TITLE
Color features by BLAST values

### DIFF
--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -125,6 +125,9 @@ def plot_operon_pairs(operons: List[Operon], other_operons: List[Operon], output
         create_operon_figure(operon,
                              plot_ignored,
                              feature_colors,
+                             color_by_blast_statistic=color_by_blast_statistic,
+                             colormin=lower,
+                             colormax=upper,
                              existing_ax=ax1,
                              figure_height=height_top)
 
@@ -133,6 +136,9 @@ def plot_operon_pairs(operons: List[Operon], other_operons: List[Operon], output
         create_operon_figure(other,
                              plot_ignored,
                              feature_colors,
+                             color_by_blast_statistic=color_by_blast_statistic,
+                             colormin=lower,
+                             colormax=upper,
                              bounds=(lower_coordinates_bound, upper_coordinates_bound),
                              existing_ax=ax2,
                              figure_height=height_bottom)


### PR DESCRIPTION
`plot_operons()` and `plot_operon_pairs()` now take a parameter `color_by_blast_feature`. If set to one of the fields on the `Feature` object, `Feature`s will be colored based on that value. The bounds of the colormap are set to the lowest and highest values among all `Feature`s, using the `viridis_r` colormap, with a log scale. Currently we only have `bit_score` and `e_val` as available values. If using `e_val`, yellow genes are high confidence hits while purple are low confidence.