### PR TITLE
Dynamically determine stacked figure dimensions

### DIFF
--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -200,8 +200,7 @@ def create_operon_figure(operon: Operon,
                            features=graphic_features)
 
     figure_width = max(int(operon_length/900), 5)
-    ax, _ = record.plot(figure_width=figure_width, figure_height=figure_height, ax=existing_ax, max_label_length=50)
-    record.plot(ax)
+    ax, _ = record.plot(figure_width=figure_width, figure_height=figure_height, ax=existing_ax, max_label_length=64)
     return ax
 
 


### PR DESCRIPTION
We're using DNA features viewer in a way its authors didn't anticipate, and so
it doesn't have the information it needs to correctly determine the
figure dimensions (though to be sure, it can also fail even when
plotting a single operon - see issue #99). This commit uses a horrendous
combination of heuristics and magic numbers to come up with dimensions that
balance many competing requirements:
  - if too narrow, the x-axis labels are squished and unreadable and
  feature labels overlap
  - if too wide, the figure looks ridiculous and it's harder to
  interpret
  - if too high, there's unused whitespace and all features are
  effectively scaled down
  - if too low, the two operons will overlap and obscure each other

This may be unappealing, but testing on a range of operons with few or
many features, and narrow and wide contigs, seems to work well. I've
examined hundreds of random examples and they all seemed effectively
flawless.

Resolves #125 