### PR TITLE
stacked clustered plots

### DIFF
--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -384,7 +384,8 @@ def _plot_clustered_stacked_operons(clustered_operons: Dict[str, List[Operon]],
     for motif_items, ops in clustered_operons.items():
         motif_name = '-'.join(motif_items)
         motif_directory = _make_motif_directory_name(motif_name, len(ops), image_directory)
-        os.mkdir(motif_directory)
+        if not os.path.exists(image_directory):
+            os.makedirs(image_directory)
         plot_operon_pairs(ops, other_operons, motif_directory, plot_ignored=plot_ignored, feature_colors=feature_colors)
 
 


### PR DESCRIPTION
This adds a function that clusters operons and then makes stacked operon figures in a separate directory for each cluster. This is useful for when a user wants to see how a particular cluster tends to be re-annotated.