### PR TITLE
Add a missing interface to the contains_group rule

### DIFF
--- a/src/operon_analyzer/rules.py
+++ b/src/operon_analyzer/rules.py
@@ -247,12 +247,11 @@ class RuleSet(object):
                                 custom_repr=custom_repr))
         return self
 
-    def contains_group(self, operon: Operon, feature_names: List[str], max_gap_distance_bp: int, require_same_orientation: bool):
+    def contains_group(self, feature_names: List[str], max_gap_distance_bp: int, require_same_orientation: bool):
         """ The operon must contain a contiguous set of features (in any order) separated by no more than max_gap_distance_bp.
         Optionally, the user may require that the features must all have the same orientation. """
         self._rules.append(Rule('contains_group',
                                 _contains_group,
-                                operon,
                                 feature_names,
                                 max_gap_distance_bp,
                                 require_same_orientation))


### PR DESCRIPTION
I forgot to add the method to RuleSet to allow the user to use the `contains_group` rule.