### PR TITLE
Temporarily disable property-based tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,4 +39,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests --runslow --runprop
+        pytest tests --runslow


### PR DESCRIPTION
These are chewing up CI hours and since this code effectively never
changes, it's not worth doing until we make the repo public.