### PR TITLE
Fix feature length

### DIFF
--- a/src/operon_analyzer/genes.py
+++ b/src/operon_analyzer/genes.py
@@ -46,7 +46,7 @@ class Feature(object):
 
     def __len__(self):
         """ Length of feature in nucleotides """
-        return self.end - self.start + 1
+        return self.end - self.start
 
     def __repr__(self) -> str:
         return f"<Feature {self.name} {self.start}..{self.end}>"

--- a/tests/test_operon_analyzer/test_genes.py
+++ b/tests/test_operon_analyzer/test_genes.py
@@ -3,8 +3,8 @@ from Bio.Seq import Seq
 
 
 def test_feature_length():
-    f = Feature('gene', (1, 100), '', 1, '', 4e-12, '', 'MGWRN', 1234.9)
-    assert len(f) == 100
+    f = Feature('gene', (0, 99), '', 1, '', 4e-12, '', 'MGWRN', 1234.9)
+    assert len(f) == 99
 
 
 def test_operon_feature_region_sequence():


### PR DESCRIPTION
Now that we've switched to zero-based indices for features, the length calculation also needs to be reduced by one.