### PR TITLE
Don't give a direction to CRISPR arrays

### DIFF
--- a/src/operon_analyzer/visualize.py
+++ b/src/operon_analyzer/visualize.py
@@ -251,14 +251,16 @@ def create_operon_figure(operon: Operon,
         # we alter the name of CRISPR arrays to add the number of repeats
         # this is done here and not earlier in the pipeline so that it doesn't
         # affect any rules that need to match on the name
+        name = feature.name
+        strand = feature.strand
         if feature.name == "CRISPR array":
             copies, repeat, spacer = feature.description.split(",")
             _, count = copies.split()
-            feature.name = f"CRISPR array ({count})"
-            feature.strand = None  # don't let array have a directional arrow
-        label = feature.name if not feature.ignored_reasons else f"{feature.name} (ignored)"
+            name = f"CRISPR array ({count})"
+            strand = None  # don't let array have a directional arrow
+        label = name if not feature.ignored_reasons else f"{name} (ignored)"
         graphic_feature = GraphicFeature(start=feature.start - offset,
-                                         strand=feature.strand,
+                                         strand=strand,
                                          end=feature.end - offset,
                                          label=label,
                                          color=color)


### PR DESCRIPTION
Due to some changes I had to make to implement `as_str()` for `Operon`s,
CRISPR arrays now have their `strand` property defined. When plotting,
this gives them a directional arrow, which is undesirable since
piler-cr's assignment of direction is probably arbitrary. This commit
ensures arrays no longer have strand defined.