### PR TITLE
Allow user to set path to BLAST

### DIFF
--- a/src/gene_finder/option_handling.py
+++ b/src/gene_finder/option_handling.py
@@ -21,7 +21,7 @@ PSIBLAST_OPTIONS = ['gap_trigger', 'num_iterations', 'out_pssm',
 BLASTN_OPTIONS = ['filtering_algorithm', 'sum_stats', 'window_masker_db', 'window_size', 'template_type', 'version', 'parse_deflines', 'min_raw_gapped_score', 'string', 'format', 'max_hsps', 'taxids', 'negative_taxids', 'num_alignments', 'strand', 'off_diagonal_range', 'subject_besthit', 'num_sequences', 'no_greedy', 'negative_taxidlist', 'culling_limit', 'xdrop_ungap', 'open_penalty', 'DUST_options', 'sorthits', 'xdrop_gap_final', 'negative_gilist', 'subject', 'use_index', 'bool_value', 'filename', 'seqidlist', 'task_name', 'sort_hits', 'database_name', 'lcase_masking', 'query_loc', 'subject_loc', 'sort_hsps', 'line_length', 'boolean', 'db_hard_mask', 'negative_seqidlist', 'template_length', 'filtering_db', 'filtering_database', 'penalty', 'searchsp', 'ungapped', 'type', 'gapextend', 'db_soft_mask', 'dbsize', 'qcov_hsp_perc', 'sorthsps', 'window_masker_taxid', 'index_name', 'export_search_strategy', 'float_value', 'soft_masking', 'gilist', 'entrez_query', 'show_gis', 'best_hit_score_edge', 'gapopen', 'subject_input_file', 'range', 'html', 'word_size', 'best_hit_overhang', 'perc_identity', 'input_file', 'num_descriptions', 'xdrop_gap', 'dust', 'taxidlist', 'max_target_seqs', 'num_threads', 'task', 'remote', 'int_value', 'extend_penalty', 'reward', 'import_search_strategy', 'num_letters']
 
 
-def build_blastp_command(query, db, evalue, kwargs, output_fields, out):
+def build_blastp_command(query, db, evalue, kwargs, output_fields, out, blastp_path):
     """
     Generate a python subprocess command (list) for
     executing blastp.
@@ -30,7 +30,7 @@ def build_blastp_command(query, db, evalue, kwargs, output_fields, out):
     at this time, only certain options are allowed.
     """
 
-    cmd = ["blastp", "-query", query, "-db", db, "-evalue", str(evalue), "-out", out]
+    cmd = [blastp_path, "-query", query, "-db", db, "-evalue", str(evalue), "-out", out]
     for key, value in kwargs.items():
         if key in (BLAST_OPTIONS_COMMON + BLASTP_OPTIONS):
             cmd.append("-{}".format(key))
@@ -42,7 +42,7 @@ def build_blastp_command(query, db, evalue, kwargs, output_fields, out):
     cmd.append("6 {}".format(output_fields))
     return cmd
 
-def build_psiblast_command(query, db, evalue, kwargs, output_fields, out):
+def build_psiblast_command(query, db, evalue, kwargs, output_fields, out, psiblast_path):
     """
     Generate a python subprocess command (list) for
     executing psiblast.
@@ -51,7 +51,7 @@ def build_psiblast_command(query, db, evalue, kwargs, output_fields, out):
     at this time, only certain options are allowed.
     """
 
-    cmd = ["psiblast", "-query", query, "-db", db, "-evalue", str(evalue), "-out", out]
+    cmd = [psiblast_path, "-query", query, "-db", db, "-evalue", str(evalue), "-out", out]
     for key, value in kwargs.items():
         if key in (BLAST_OPTIONS_COMMON + PSIBLAST_OPTIONS):
             cmd.append("-{}".format(key))
@@ -63,7 +63,7 @@ def build_psiblast_command(query, db, evalue, kwargs, output_fields, out):
     cmd.append("6 {}".format(output_fields))
     return cmd
 
-def build_blastn_command(query, db, evalue, kwargs, output_fields, out):
+def build_blastn_command(query, db, evalue, kwargs, output_fields, out, blastn_path):
     """
     Generate a python subprocess command (list) for
     executing blastn.
@@ -71,7 +71,7 @@ def build_blastn_command(query, db, evalue, kwargs, output_fields, out):
     kwargs should be valid blastn options. 
     """
 
-    cmd = ["blastn", "-query", query, "-db", db, "-evalue", str(evalue), "-out", out]
+    cmd = [blastn_path, "-query", query, "-db", db, "-evalue", str(evalue), "-out", out]
     for key, value in kwargs.items():
         if key in BLASTN_OPTIONS:
             cmd.append("-{}".format(key))

--- a/src/gene_finder/pipeline.py
+++ b/src/gene_finder/pipeline.py
@@ -262,7 +262,7 @@ class Pipeline:
             self._neighborhood_orfs[key] = path
 
     
-    def add_seed_step(self, db, name, e_val, blast_type, sensitivity=None, parse_descriptions=True, **kwargs):
+    def add_seed_step(self, db, name, e_val, blast_type, sensitivity=None, parse_descriptions=True, blast_path=None, **kwargs):
         """Add a seed step to the pipeline. 
 
         Internally, this queues a series of sub-steps that
@@ -310,9 +310,11 @@ class Pipeline:
             be first. Additional steps can occur in any order.
         """
         if blast_type in ("PROT", "blastp"):
-            self._steps.append(SeedStep(Blastp(db, e_val, name, parse_descriptions, kwargs)))
+            path = 'blastp' if blast_path is None else blast_path
+            self._steps.append(SeedStep(Blastp(db, e_val, name, parse_descriptions, path, kwargs)))
         elif blast_type in ("PSI", "psiblast"):
-            self._steps.append(SeedStep(Blastpsi(db, e_val, name, parse_descriptions, kwargs)))
+            path = 'psiblast' if blast_path is None else blast_path
+            self._steps.append(SeedStep(Blastpsi(db, e_val, name, parse_descriptions, path, kwargs)))
         elif blast_type == "mmseqs":
             self._steps.append(SeedStep(MMseqs(db, str(e_val), name, str(sensitivity), parse_descriptions)))
         elif blast_type == "diamond":
@@ -323,7 +325,7 @@ class Pipeline:
 
     def add_seed_with_coordinates_step(self, db, name, e_val, blast_type, sensitivity=None, 
                                        parse_descriptions=True, start=None, end=None, 
-                                       contig_id=None, **kwargs):
+                                       contig_id=None, blast_path=None, **kwargs):
         """
         Define a genomic region to search with coordinates instead of a bait gene.
 
@@ -360,11 +362,11 @@ class Pipeline:
         """
         self._steps.append(SeedWithCoordinatesStep(start=start, end=end, contig_id=contig_id))
         self.add_blast_step(db=db, name=name, e_val=e_val, blast_type=blast_type, 
-                            sensitivity=sensitivity, parse_descriptions=parse_descriptions, **kwargs)
+                            sensitivity=sensitivity, parse_descriptions=parse_descriptions, blast_path=blast_path, **kwargs)
 
 
     def add_filter_step(self, db, name, e_val, blast_type, min_prot_count=1, 
-                        sensitivity=None, parse_descriptions=True, **kwargs):
+                        sensitivity=None, parse_descriptions=True, blast_path=None, **kwargs):
         """Add a filter step to the pipeline.
 
         Blast genomic neighborhoods against the target database. 
@@ -401,9 +403,11 @@ class Pipeline:
                 is set to mmseqs or diamond, kwargs will be silently ignored.
         """
         if blast_type in ("PROT", "blastp"):
-            self._steps.append(FilterStep(Blastp(db, e_val, name, parse_descriptions, kwargs), min_prot_count))
+            path = 'blastp' if blast_path is None else blast_path
+            self._steps.append(FilterStep(Blastp(db, e_val, name, parse_descriptions, path, kwargs), min_prot_count))
         elif blast_type in ("PSI", "psiblast"):
-            self._steps.append(FilterStep(Blastpsi(db, e_val, name, parse_descriptions, kwargs), min_prot_count))
+            path = 'psiblast' if blast_path is None else blast_path
+            self._steps.append(FilterStep(Blastpsi(db, e_val, name, parse_descriptions, path, kwargs), min_prot_count))
         elif blast_type == "mmseqs":
             self._steps.append(FilterStep(MMseqs(db, str(e_val), name, str(sensitivity), parse_descriptions), min_prot_count))
         elif blast_type == "diamond":
@@ -413,7 +417,7 @@ class Pipeline:
     
     
     def add_blast_step(self, db, name, e_val, blast_type, 
-                        sensitivity=None, parse_descriptions=True, **kwargs):
+                        sensitivity=None, parse_descriptions=True, blast_path=None, **kwargs):
         """Add a non-filtering blast step to the pipeline.
 
         Blast genomic neighborhoods against the target database. 
@@ -448,9 +452,11 @@ class Pipeline:
                 is set to mmseqs or diamond, kwargs will be silently ignored.     
         """
         if blast_type in ("PROT", "blastp"):
-            self._steps.append(SearchStep(Blastp(db, e_val, name, parse_descriptions, kwargs)))
+            path = 'blastp' if blast_path is None else blast_path
+            self._steps.append(SearchStep(Blastp(db, e_val, name, parse_descriptions, path, kwargs)))
         elif blast_type in ("PSI", "psiblast"):
-            self._steps.append(SearchStep(Blastpsi(db, e_val, name, parse_descriptions, kwargs)))
+            path = 'psiblast' if blast_path is None else blast_path
+            self._steps.append(SearchStep(Blastpsi(db, e_val, name, parse_descriptions, path, kwargs)))
         elif blast_type == "mmseqs":
             self._steps.append(SearchStep(MMseqs(db, str(e_val), name, str(sensitivity), parse_descriptions)))
         elif blast_type == "diamond":
@@ -469,10 +475,10 @@ class Pipeline:
 
         self._steps.append(CrisprStep(Pilercr("CRISPR")))
     
-    def add_blastn_step(self, db, name, e_val, parse_descriptions=False, **kwargs):
+    def add_blastn_step(self, db, name, e_val, parse_descriptions=False, blastn_path='blastn', **kwargs):
         """ Add a step to do nucleotide BLAST. """
         
-        self._steps.append(BlastnStep(Blastn(db, name, e_val, parse_descriptions, kwargs)))
+        self._steps.append(BlastnStep(Blastn(db, name, e_val, parse_descriptions, blastn_path, kwargs)))
 
 
     def _update_output_sequences(self):

--- a/src/gene_finder/steps.py
+++ b/src/gene_finder/steps.py
@@ -1,13 +1,18 @@
-from Bio.Blast.Applications import (NcbiblastpCommandline, 
+import multiprocessing
+import os
+import subprocess
+import tempfile
+
+from Bio.Blast.Applications import (NcbiblastpCommandline,
                                     NcbipsiblastCommandline)
 
+from gene_finder.option_handling import (build_blastn_command,
+                                         build_blastp_command,
+                                         build_psiblast_command)
+from gene_finder.parsers import (parse_blastn_output, parse_pilercr_summary,
+                                 parse_search_output)
 from gene_finder.utils import get_neighborhood_ranges
-from gene_finder.parsers import parse_search_output, parse_pilercr_summary, parse_blastn_output
-from gene_finder.option_handling import (build_blastp_command,
-                                        build_blastn_command,
-                                        build_psiblast_command)
 
-import os, subprocess, tempfile, multiprocessing
 
 class Blastp():
     """Wrapper for NCBI Blastp command line util.
@@ -20,17 +25,18 @@ class Blastp():
         nident mismatch positive gapopen \
         gaps ppos qcovhsp qseq"
 
-    def __init__(self, db, e_val, step_id, parse_descriptions, kwargs):
+    def __init__(self, db, e_val, step_id, parse_descriptions, blastp_path, kwargs):
 
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.db = db
         self.e_val = e_val
         self.step_id = step_id
         self.parse_descriptions = parse_descriptions
+        self.blastp_path = blastp_path
         self.kwargs = kwargs
     
     def construct_cmd(self, query, out):
-        return build_blastp_command(query, self.db, self.e_val, self.kwargs, self.BLASTOUT_FIELDS, out)
+        return build_blastp_command(query, self.db, self.e_val, self.kwargs, self.BLASTOUT_FIELDS, out, self.blastp_path)
 
     def run(self, orfs):
 
@@ -51,17 +57,18 @@ class Blastpsi():
         nident mismatch positive gapopen \
         gaps ppos qcovhsp qseq"
 
-    def __init__(self, db, e_val, step_id, parse_descriptions, kwargs):
+    def __init__(self, db, e_val, step_id, parse_descriptions, psiblast_path, kwargs):
 
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.db = db
         self.e_val = e_val
         self.step_id = step_id
         self.parse_descriptions = parse_descriptions
+        self.psiblast_path = psiblast_path
         self.kwargs = kwargs
     
     def construct_cmd(self, query, out):
-        return build_psiblast_command(query, self.db, self.e_val, self.kwargs, self.BLASTOUT_FIELDS, out)
+        return build_psiblast_command(query, self.db, self.e_val, self.kwargs, self.BLASTOUT_FIELDS, out, self.psiblast_path)
 
     def run(self, orfs):
 
@@ -189,16 +196,17 @@ class Blastn():
         nident mismatch positive gapopen \
         gaps ppos qcovhsp qseq qstart qend sstrand"
 
-    def __init__(self, db, step_id, e_val, parse_descriptions, kwargs):
+    def __init__(self, db, step_id, e_val, parse_descriptions, blastn_path, kwargs):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.db = db
         self.step_id = step_id
         self.e_val = e_val
         self.parse_descriptions = parse_descriptions
+        self.blastn_path = blastn_path
         self.kwargs = kwargs
     
     def construct_cmd(self, query, out):
-        return build_blastn_command(query, self.db, self.e_val, self.kwargs, self.BLASTOUT_FIELDS, out)
+        return build_blastn_command(query, self.db, self.e_val, self.kwargs, self.BLASTOUT_FIELDS, out, self.blastn_path)
 
     def run(self, genome):
 

--- a/tests/test_gene_finder/test_options.py
+++ b/tests/test_gene_finder/test_options.py
@@ -4,7 +4,7 @@ def test_build_command1():
     # simply tests that the subprocess argument list is being constructed as expected
     kwargs = {"num_threads": 4, "ungapped": True, "qcov_hsp_perc": 90}
     cmd = build_blastp_command(query="my_query", db="my_db", evalue=0.001, kwargs=kwargs, 
-                               output_fields="qseqid sseqid stitle", out="out.tsv")
+                               output_fields="qseqid sseqid stitle", out="out.tsv", blastp_path='blastp')
     assert cmd == ["blastp", "-query", "my_query", "-db", "my_db", "-evalue", "0.001", "-out", "out.tsv",
                    "-num_threads", "4", "-ungapped", "-qcov_hsp_perc", "90", "-outfmt", "6 qseqid sseqid stitle"]
 
@@ -13,7 +13,7 @@ def test_build_command2():
     # tests that unknown/prohibited arguments are ignored
     kwargs = {"not_a_real": "blast_argument", "outfmt": 2}
     cmd = build_blastp_command(query="my_query", db="my_db", evalue=0.001, kwargs=kwargs, 
-                               output_fields="qseqid sseqid stitle", out="out.tsv")
+                               output_fields="qseqid sseqid stitle", out="out.tsv", blastp_path='blastp')
     assert cmd == ["blastp", "-query", "my_query", "-db", "my_db", "-evalue", "0.001", "-out", "out.tsv",
                    "-outfmt", "6 qseqid sseqid stitle"]
 
@@ -22,6 +22,6 @@ def test_build_command3():
     # test the psi blast version of this, for good measure
     kwargs = {"num_iterations": 3, "gap_trigger": 24}
     cmd = build_psiblast_command(query="my_query", db="my_db", evalue=0.001, kwargs=kwargs, 
-                               output_fields="qseqid sseqid stitle", out="out.tsv")
+                               output_fields="qseqid sseqid stitle", out="out.tsv", psiblast_path='psiblast')
     assert cmd == ["psiblast", "-query", "my_query", "-db", "my_db", "-evalue", "0.001", "-out", "out.tsv",
                    "-num_iterations", "3", "-gap_trigger", "24", "-outfmt", "6 qseqid sseqid stitle"]


### PR DESCRIPTION
Users can choose the path to the executable they want to use. If no
selection is made, it will default to 'blastp', 'blastn', or 'psiblast',
as appropriate. This will make it easy to use v2.10 of blastp or blastn on
our cluster.

Resolves #114