### PR TITLE
Fix newline error in as_str

### DIFF
--- a/src/operon_analyzer/genes.py
+++ b/src/operon_analyzer/genes.py
@@ -225,4 +225,4 @@ class Operon(object):
             feature_coords = f"{feature.start + 1}..{feature.end}" if feature.strand == 1 else f"{feature.end}..{feature.start + 1}"
             strand = feature.strand if feature.name != 'CRISPR array' else ''
             writer.writerow([f"{self.contig}",f"{self.start}..{self.end}",f"{feature.name}",f"{feature_coords}",f"{feature.orfid}",f"{strand}",f"{feature.accession}",f"{optional_evalue(feature.e_val)}",f"{feature.description}",f"{feature.sequence}",f"{optional_float_or_int(feature.bit_score)}",f"{optional(feature.raw_score)}",f"{optional(feature.aln_len)}",f"{optional_float(feature.pident, 3)}",f"{optional(feature.nident)}",f"{optional(feature.mismatch)}",f"{optional(feature.positive)}",f"{optional(feature.gapopen)}",f"{optional(feature.gaps)}",f"{optional_float(feature.ppos, 2)}",f"{optional(feature.qcovhsp)}",f"{self.contig_filename}"])
-        return "%s" % output.getvalue().strip().replace("\r", "")
+        return "%s" % output.getvalue().replace("\r", "")

--- a/tests/test_operon_analyzer/test_genes.py
+++ b/tests/test_operon_analyzer/test_genes.py
@@ -4,7 +4,7 @@ from Bio.Seq import Seq
 
 
 def test_serialize_operon_roundtrip():
-    line = "forward,473846..494916,cas5,485260..488403,lcl|485260|488403|1|1,1,UniRef50_D3I2J9,7.28e-113,UniRef50_D3I2J9 cas5 Putative CRISPR-associated protein Csc1 n=138 RepID=D3I2J9_9BACT,MNLTLKTLLALNLTLI,374,959,1037,29.219,303,617,498,30,117,48.02,93,forward.fa"
+    line = "forward,473846..494916,cas5,485260..488403,lcl|485260|488403|1|1,1,UniRef50_D3I2J9,7.28e-113,UniRef50_D3I2J9 cas5 Putative CRISPR-associated protein Csc1 n=138 RepID=D3I2J9_9BACT,MNLTLKTLLALNLTLI,374,959,1037,29.219,303,617,498,30,117,48.02,93,forward.fa\n"
     operon = list(load.load_operons([line]))[0]
     actual = operon.as_str()
     assert actual == line


### PR DESCRIPTION
`Operon.as_str()` was incorrectly concatenating the last line of one operon with the first line of the next.