### PR TITLE
Contributing guide

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+Thank you for your interest in contributing to Opfi. Contribututions can take many forms, including:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+
+## Issues
+Issues should be used to report problems or bugs with the library, to request new features, or to discuss potential changes before PRs are created.
+
+Good bug reports have:
+
+- A summary of the issue
+- Specific steps to reproduce the problem, preferably in the form of code examples
+- A description of expected behavior
+- A description of actual behavior
+
+## Pull Requests
+In general, we use [Github Flow](https://guides.github.com/introduction/flow/index.html). This means that all changes happen through Pull Requests:
+
+1. Fork the repository to your own Github account
+2. Clone the project to your machine
+3. Create a branch locally with a succinct but descriptive name
+4. Commit changes to the branch
+5. Push changes to your fork
+6. Open a PR in our repository and include a description of the changes and a reference to the issue the PR addresses
+
+## Coding Style
+Contributors should attempt to adhere to the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guide when possible, although this is not currently strictly enforced. At a minimum, new contributions should follow a style that is consistent with the preexisting code base. 
+
+## Testing
+We use the [pytest](https://docs.pytest.org/en/6.2.x/) framework for creating unit tests. Please write tests for any new code contributed to this project.
+
+## License
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+## Code of Conduct
+We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct.]()
+
+## Attribution
+This document was adapted from the [General Contributing Guidelines](https://github.com/extendr/rextendr/blob/main/CONTRIBUTING.md) of the rextendr project, and from the [contributing template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62) developed by [briandk](https://gist.github.com/briandk).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We use the [pytest](https://docs.pytest.org/en/6.2.x/) framework for creating un
 By contributing, you agree that your contributions will be licensed under its MIT License.
 
 ## Code of Conduct
-We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct.]()
+We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/wilkelab/Opfi/blob/contributing-guide/CODE-OF-CONDUCT.md).
 
 ## Attribution
 This document was adapted from the [General Contributing Guidelines](https://github.com/extendr/rextendr/blob/main/CONTRIBUTING.md) of the rextendr project, and from the [contributing template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62) developed by [briandk](https://gist.github.com/briandk).


### PR DESCRIPTION
Adds a simple contributor guide for Opfi. This is adapted from the [rextender](https://github.com/extendr/rextendr/blob/main/CONTRIBUTING.md) project, and from [this template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62) developed by briandk. 

Also adds a code of conduct downloaded from https://www.contributor-covenant.org/version/1/4/code-of-conduct/
