### PR TITLE
fix inaccurate description of pytest usage

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,9 +38,15 @@ Opfi makes use of several third-party softwares for finding and annotating genom
 Testing your build
 ------------------
 
-Users who opt to build Opfi from source can test their build by running the command `pytest --runslow` from the project root directory. Note that this assumes NCBI BLAST+ has already been installed. The following flags can direct pytest to test any optional depencies, as needed.
+Users who opt to build Opfi from source can test their build by running ``pytest`` from the project root directory. The following flags will direct pytest to run specific sets of tests (in addition to the core suite):
 
-* `--rundiamond`: run tests that require Diamond.
-* `--runmmseqs`: run tests that require MMseqs2.
-* `--runpiler`: run tests that require PILER-CR.
-* `--rungrf`: run tests that require GenericRepeatFinder.
+* ``--runmmseqs``: Run tests that require MMseqs2.
+* ``--rundiamond``: Run tests that require Diamond.
+* ``--runslow``: Run integration/end-to-end tests.
+* ``--runprop``: Run very slow property tests.
+
+For most users, running ``pytest --runslow`` is recommended. 
+
+.. note::
+
+    Several tests in the core suite require :program:`BLAST`, :program:`PILER-CR`, and/or :program:`GenericRepeatFinder`. Running ``pytest`` without first installing these dependencies will cause these tests to fail. 


### PR DESCRIPTION
In the old version of the docs, I had mentioned some custom pytest flags that don't actually exist. I was going to use `pytest.getoptions` and `pytest.mark.skip` features to skip tests with piler and GRF as dependencies, unless a corresponding flag is used. 

I decided this is more tedious than is worth doing at the present time, so this PR just amends the documentation so that it doesn't mention the nonexistent pytest options. 